### PR TITLE
one approach to fix #7

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var dotPropGet = require('dot-prop').get;
+var compareFunc = require('compare-func');
 
 module.exports = function (arr, prop) {
 	if (!Array.isArray(arr)) {
@@ -8,29 +8,7 @@ module.exports = function (arr, prop) {
 
 	arr = arr.slice();
 
-	(Array.isArray(prop) ? prop : [prop]).forEach(function (el) {
-		arr.sort(function (a, b) {
-			if (typeof el === 'function') {
-				a = el(a);
-				b = el(b);
-			}
-
-			if (typeof el === 'string') {
-				a = dotPropGet(a, el);
-				b = dotPropGet(b, el);
-			}
-
-			if (typeof a === 'string' && typeof b === 'string') {
-				return a.localeCompare(b);
-			}
-
-			if (a === b) {
-				return 0;
-			}
-
-			return a < b ? -1 : 1;
-		});
-	});
+	arr.sort(compareFunc(prop));
 
 	return arr;
 };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "get"
   ],
   "dependencies": {
-    "dot-prop": "^2.0.0"
+    "compare-func": "^1.2.0"
   },
   "devDependencies": {
     "ava": "0.0.4"

--- a/test.js
+++ b/test.js
@@ -50,11 +50,19 @@ test(function (t) {
 		}
 	])[0].bar === 'a');
 
-	t.assert(sortOn([
+	var arr = sortOn([
 		{bar: 'b'},
 		{foo: 'b'},
 		{foo: 'a'}
-	], 'foo')[0].foo === 'a');
+	], 'foo');
+
+	arr.some(function (el) {
+		var foo = el.foo;
+		if (foo) {
+			t.assert(foo === 'a');
+			return true;
+		}
+	});
 
 	t.assert(sortOn([
 		{foo: 'b', bar: 'a'},


### PR DESCRIPTION
I don't know if my explanation in #7 makes sense but this is a demo. 
I think it's easier to put `(Array.isArray(prop) ? prop : [prop]).forEach` loop in the compare function because it's easier to move onto the second property without changing the order that's already sorted by the first property (unless they are the same value). 