### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,43 @@
+declare namespace sortOn {
+	type Property<T> = string | string[] | ((element: T) => unknown) | ((element: T) => unknown)[];
+}
+
+/**
+Sort an array on an object property.
+
+@param array - The array to sort.
+@param property - The string can be a [dot path](https://github.com/sindresorhus/dot-prop) to a nested object property. Prepend it with `-` to sort it in descending order.
+@returns A new sorted version of the given array.
+
+@example
+```
+import sortOn = require('sort-on');
+
+// Sort by an object property
+sortOn([{x: 'b'}, {x: 'a'}, {x: 'c'}], 'x');
+//=> [{x: 'a'}, {x: 'b'}, {x: 'c'}]
+
+// Sort descending by an object property
+sortOn([{x: 'b'}, {x: 'a'}, {x: 'c'}], '-x');
+//=> [{x: 'c'}, {x: 'b'}, {x: 'a'}]
+
+// Sort by a nested object property
+sortOn([{x: {y: 'b'}}, {x: {y: 'a'}}], 'x.y');
+//=> [{x: {y: 'a'}}, {x: {y: 'b'}}]
+
+// Sort descending by a nested object property
+sortOn([{x: {y: 'b'}}, {x: {y: 'a'}}], '-x.y');
+//=> [{x: {y: 'b'}, {x: {y: 'a'}}}]
+
+// Sort by the `x` property, then `y`
+sortOn([{x: 'c', y: 'c'}, {x: 'b', y: 'a'}, {x: 'b', y: 'b'}], ['x', 'y']);
+//=> [{x: 'b', y: 'a'}, {x: 'b', y: 'b'}, {x: 'c', y: 'c'}]
+
+// Sort by the returned value
+sortOn([{x: 'b'}, {x: 'a'}, {x: 'c'}], el => el.x);
+//=> [{x: 'a'}, {x: 'b'}, {x: 'c'}]
+```
+*/
+declare function sortOn<T>(array: readonly T[], property: sortOn.Property<T>): T[];
+
+export = sortOn;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,14 @@
+import {expectType} from 'tsd';
+import sortOn = require('.');
+
+expectType<string>(sortOn([{x: 'b'}, {x: 'a'}, {x: 'c'}], 'x')[0].x);
+expectType<any>(sortOn<any>([{x: 'b'}, {x: 'a'}, {x: 'c'}], 'x')[0].x);
+
+expectType<string>(sortOn([{x: 'b'}, {x: 'a'}, {x: 'c'}], ['x'])[0].x);
+expectType<string>(sortOn([{x: 'b'}, {x: 'a'}, {x: 'c'}], element => element.x)[0].x);
+expectType<string>(sortOn([{x: 'b'}, {x: 'a'}, {x: 'c'}], [element => element.x])[0].x);
+
+const property: sortOn.Property<string> = string => expectType<string>(string);
+expectType<string>(sortOn(['a', 'bb', 'ccc'], property)[0]);
+
+sortOn(['a', 'bb', 'ccc'] as const, 'length');

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
+		"index.d.ts",
 		"index.js"
 	],
 	"keywords": [
@@ -35,6 +36,7 @@
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",
+		"tsd": "^0.7.4",
 		"xo": "^0.24.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
 		"test": "xo && ava && tsd"
 	},
 	"files": [
-		"index.d.ts",
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"sort",


### PR DESCRIPTION
I made it so that `Property<T>` is an exported type, in case someone wanted to expose an API e.g. like `getFoobars(sortedOn: Property<Foobar>): Foobar[]`, let me know if you would prefer without it 👌 