### PR TITLE
Fix TypeScript type for function and string array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace sortOn {
-	type Property<T> = string | string[] | ((element: T) => unknown) | ((element: T) => unknown)[];
+	type Property<T> = string | ((element: T) => unknown) | (string | ((element: T) => unknown))[];
 }
 
 /**

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,6 +7,7 @@ expectType<any>(sortOn<any>([{x: 'b'}, {x: 'a'}, {x: 'c'}], 'x')[0].x);
 expectType<string>(sortOn([{x: 'b'}, {x: 'a'}, {x: 'c'}], ['x'])[0].x);
 expectType<string>(sortOn([{x: 'b'}, {x: 'a'}, {x: 'c'}], element => element.x)[0].x);
 expectType<string>(sortOn([{x: 'b'}, {x: 'a'}, {x: 'c'}], [element => element.x])[0].x);
+expectType<string>(sortOn([{x: 'b', y: 1}, {x: 'a', y: 2}, {x: 'c', y: 1}], [element => element.x, 'y'])[0].x);
 
 const property: sortOn.Property<string> = string => expectType<string>(string);
 expectType<string>(sortOn(['a', 'bb', 'ccc'], property)[0]);

--- a/test.js
+++ b/test.js
@@ -73,6 +73,16 @@ test('main', t => {
 		prop => prop.bar
 	])[0].bar, 2);
 
+	t.is(sortOn([
+		{foo: 2, bar: 1},
+		{foo: 1, bar: 2},
+		{foo: 1, bar: 3},
+		{foo: 3, bar: 3}
+	], [
+		prop => prop.foo,
+		'bar'
+	])[0].bar, 2);
+
 	const sorted = sortOn([
 		{bar: 'b'},
 		{foo: 'b'},


### PR DESCRIPTION
Found out that this TypeScript complained when I tried to do:

```ts
return sortOn(pool, [
  (openOrder) => openOrder.state === OpenOrderState.Pending,
  '_updated_at'
])
```