### PR TITLE
Fix sorting of bigint zeroes

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,11 @@ export default function sortOn(array, property, {locales, localeOptions} = {}) {
 				return false;
 			}
 
+			if (typeof x === 'bigint' && typeof y === 'bigint') {
+				returnValue = isDescending ? (x < y ? 1 : -1) : (x < y ? -1 : 1);
+				return returnValue !== 0;
+			}
+
 			if (y !== 0 && !y) {
 				returnValue = isDescending ? 1 : -1;
 				return true;

--- a/test.js
+++ b/test.js
@@ -181,4 +181,28 @@ test('main', t => {
 		{foo: 'a11'},
 		{foo: 'a25'},
 	]);
+
+	t.deepEqual(sortOn([
+		{foo: 2n},
+		{foo: 0n},
+		{foo: 3n},
+		{foo: 1n},
+	], 'foo'), [
+		{foo: 0n},
+		{foo: 1n},
+		{foo: 2n},
+		{foo: 3n},
+	]);
+
+	t.deepEqual(sortOn([
+		{foo: 2n},
+		{foo: 0n},
+		{foo: 3n},
+		{foo: 1n},
+	], '-foo'), [
+		{foo: 3n},
+		{foo: 2n},
+		{foo: 1n},
+		{foo: 0n},
+	]);
 });


### PR DESCRIPTION
Before this change, `0n` was always sorted last, both when using ascending and descending sorting.

This patch works gracefully on environments without support for `BigInt`, since we are only using `typeof` and comparing to a string, not special BigInt operators...